### PR TITLE
test: add segmentation gap test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "jszip": "^3.10.1",
@@ -28,6 +29,8 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "@types/node": "^20.0.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/lib/segmentation.test.ts
+++ b/src/lib/segmentation.test.ts
@@ -1,0 +1,32 @@
+import { analyze } from './segmentation'
+import type { Point, AnalyseParams } from '../types'
+
+import { describe, expect, it } from 'vitest'
+
+describe('segmentation analyze', () => {
+  it('splits rides when encountering a large time gap', () => {
+    const params: AnalyseParams = {
+      vMinKmh: 1,
+      dMinM: 0,
+      rideMinMin: 0,
+      stopMinMin: 0,
+      gapSplitMin: 5,
+    }
+
+    const points: Point[] = [
+      { t: 0, lat: 0, lon: 0 },
+      { t: 60_000, lat: 0, lon: 0.001 },
+      { t: 120_000, lat: 0, lon: 0.002 },
+      // gap of 10 minutes
+      { t: 720_000, lat: 0, lon: 0.003 },
+      { t: 780_000, lat: 0, lon: 0.004 },
+    ]
+
+    const { rides } = analyze(points, params)
+
+    expect(rides.length).toBe(2)
+    expect(rides[0].endIdx).toBe(2)
+    expect(rides[1].startIdx).toBe(3)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add vitest test script and dev deps
- add unit test for time gap splitting in analyze

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_b_68af5d549a8c83219d43fa0fcf7dc3c2