### PR TITLE
Overlay map zoom controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import './styles.css'
 import { Dropzone } from './components/Dropzone'
 import { MapView } from './components/MapView'
 import { SpeedChart } from './components/SpeedChart'
-import type { AnalysisResult, Ride } from './types'
+import type { AnalysisResult } from './types'
 
 
 import { ParamControls } from './components/ParamControls'
@@ -131,7 +131,7 @@ export default function App() {
 
       <div style={{ display: 'grid', gridTemplateRows: '1fr auto', minHeight: 0 }}>
         <div className="section" style={{ margin: '12px 12px 6px' }}>
-          <div style={{ height: 'calc(100vh - 360px)' }}>
+          <div style={{ position: 'relative', height: 'calc(100vh - 360px)' }}>
             <MapView
               data={data}
               selectedRide={selectedRideId}
@@ -139,10 +139,19 @@ export default function App() {
               zoomRideId={zoomRideId}
               onZoomDone={() => setZoomRideId(null)}
               zoomAllNonce={zoomAllNonce}
-            /></div>
-          <div className="row" style={{ margin: '6px 12px' }}>
-            <button className="btn" disabled={!selectedRideId} onClick={() => setZoomRideId(selectedRideId)}>Zoom op rit</button>
-            <button className="btn" onClick={zoomAll} disabled={!data}>Reset zoom</button>
+            />
+            <div className="map-controls">
+              <button
+                className="btn"
+                disabled={!selectedRideId}
+                onClick={() => setZoomRideId(selectedRideId)}
+              >
+                Zoom op rit
+              </button>
+              <button className="btn" onClick={zoomAll} disabled={!data}>
+                Reset zoom
+              </button>
+            </div>
           </div>
         </div>
         <div className="section" style={{ margin: '6px 12px 12px' }}>

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef } from 'react'
 import maplibregl, { LngLatBoundsLike, LngLatLike, Map } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import type { AnalysisResult, Ride } from '../types'
+import type { Feature, Point } from 'geojson'
+import type { AnalysisResult } from '../types'
 
 
 function rideColor(i: number) {
@@ -110,11 +111,11 @@ export function MapView({
 
 
         // Stops as points
-        const stopFeatures = data.stops.map(s => ({
+        const stopFeatures: Feature<Point, { id: number; duration: number }>[] = data.stops.map(s => ({
             type: 'Feature',
             properties: { id: s.id, duration: s.durationS },
-            geometry: { type: 'Point', coordinates: [s.centroid.lon, s.centroid.lat] }
-        })) as any
+            geometry: { type: 'Point', coordinates: [s.centroid.lon, s.centroid.lat] },
+        }))
 
 
         map.addSource('stops', { type: 'geojson', data: { type: 'FeatureCollection', features: stopFeatures } })

--- a/src/components/SpeedChart.tsx
+++ b/src/components/SpeedChart.tsx
@@ -17,14 +17,14 @@ export function SpeedChart({ data, ride }: { data: AnalysisResult | null, ride: 
         const y = pts.map(p => p.speedKmh || 0)
 
 
-        const trace = { x, y, mode: 'lines', type: 'scattergl', name: 'Snelheid (km/h)' } as any
+        const trace = { x, y, mode: 'lines', type: 'scattergl', name: 'Snelheid (km/h)' }
         const layout = {
             margin: { l: 40, r: 10, t: 10, b: 30 },
             paper_bgcolor: 'rgba(0,0,0,0)', plot_bgcolor: 'rgba(0,0,0,0)',
             xaxis: { title: 'Tijd', gridcolor: '#374151' },
             yaxis: { title: 'km/h', gridcolor: '#374151' },
             font: { color: '#e5e7eb' },
-        } as any
+        }
 
 
         Plotly.newPlot(ref.current, [trace], layout, { responsive: true, displaylogo: false })

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,14 @@ body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, s
 .item { padding:8px; border-radius:12px; background:#0f172a; cursor:pointer; border:1px solid #1f2937; }
 .item.active { outline: 2px solid var(--accent); }
 .map { height: 100%; }
+.map-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 .chart { height: 280px; background: var(--card); border-radius: 16px; padding: 6px; }
 .drop { border:2px dashed #374151; border-radius:12px; padding:16px; text-align:center; background:#0b1224; }
 .stats { display:grid; grid-template-columns:1fr 1fr; gap:8px; }


### PR DESCRIPTION
## Summary
- Float 'Zoom op rit' and 'Reset zoom' buttons over the map and position them top-right to free space
- Add `.map-controls` overlay styles and remove unused types/any casts for cleaner lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af617bc08083219056a6cc7cd87061